### PR TITLE
Remove tsc compilation of individual files

### DIFF
--- a/.github/workflows/publish-style-spec.yml
+++ b/.github/workflows/publish-style-spec.yml
@@ -48,7 +48,6 @@ jobs:
           npm run generate-style-spec
           npm run generate-typings
           npm run build
-          npm run compile
 
       - name: Build Release Notes
         id: release_notes


### PR DESCRIPTION
Due to the old docs, we had to be able to reach each file as a .js, and tsc compiling everything to a /tsc folder was the workaround.

Now we just use the typescript or the bundle instead.