### PR TITLE
Add CSS Color 4 syntax support, color interpolation changes

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,15 +1,17 @@
 import type {Config} from 'jest';
 
-const sharedConfig = {
+const sharedConfig: Partial<Config> = {
     transform: {
         // use typescript to convert from esm to cjs
         '[.](m|c)?(ts|js)(x)?$': ['ts-jest', {
-            'isolatedModules': true,
+            isolatedModules: true,
         }],
     },
     // any tests that operate on dist files shouldn't compile them again.
-    transformIgnorePatterns: ['<rootDir>/dist']
-} as Partial<Config>;
+    transformIgnorePatterns: ['<rootDir>/dist'],
+    // load custom jest matchers
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};
 
 const config: Config = {
     projects: [

--- a/jest.d.ts
+++ b/jest.d.ts
@@ -1,0 +1,21 @@
+declare global {
+    namespace jest {
+        interface Matchers<R> { // eslint-disable-line @typescript-eslint/no-unused-vars
+
+            /**
+             * @param expectedSerialized Color serialized as string in format 'rgb(r% g% b% / alpha)'
+             * @param numDigits `expect.closeTo` numDigits parameter
+             */
+            toMatchColor(expectedSerialized: string, numDigits?: number): void;
+
+            /**
+             * @param expectedArray Expected array of numbers.
+             * @param numDigits `expect.closeTo` numDigits parameter
+             */
+            closeToNumberArray(expectedArray: number[], numDigits?: number): void;
+
+        }
+    }
+}
+
+export {};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,29 @@
+import Color from './src/util/color';
+
+expect.extend({
+
+    toMatchColor(received: unknown, expectedSerialized: string, numDigits = 5) {
+        const [r, g, b, a] = expectedSerialized.match(/^rgb\(([\d.]+)% ([\d.]+)% ([\d.]+)% \/ ([\d.]+)\)$/).slice(1).map(Number);
+        const expected = expect.objectContaining({
+            r: expect.closeTo(r / 100 * a, numDigits),
+            g: expect.closeTo(g / 100 * a, numDigits),
+            b: expect.closeTo(b / 100 * a, numDigits),
+            a: expect.closeTo(a, 4),
+        });
+        const pass = (received instanceof Color) && this.equals(received, expected);
+        return {
+            pass,
+            message: () => `${this.utils.matcherHint('toMatchColor', this.utils.printReceived(received), expectedSerialized)}\n\n${this.utils.diff(expected, received)}`,
+        };
+    },
+
+    closeToNumberArray(received: unknown, expectedArray: number[], numDigits = 5) {
+        const expected = expectedArray.map(n => isNaN(n) ? n : expect.closeTo(n, numDigits));
+        const pass = this.equals(received, expected);
+        return {
+            pass,
+            message: () => `${this.utils.matcherHint('closeToNumberArray', this.utils.printReceived(received), this.utils.printExpected(expectedArray))}\n\n${this.utils.diff(expected, received)}`,
+        };
+    },
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/unitbezier": "^0.0.1",
         "@types/mapbox__point-geometry": "^0.1.2",
-        "csscolorparser": "~1.0.3",
+        "color-string": "^1.9.1",
         "json-stringify-pretty-compact": "^3.0.0",
         "minimist": "^1.2.8",
         "rw": "^1.3.3",
@@ -2715,8 +2715,16 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2782,11 +2790,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "node_modules/cssfontparser": {
       "version": "1.2.1",
@@ -6895,6 +6898,19 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@mapbox/point-geometry": "^0.1.0",
     "@mapbox/unitbezier": "^0.0.1",
     "@types/mapbox__point-geometry": "^0.1.2",
-    "csscolorparser": "~1.0.3",
+    "color-string": "^1.9.1",
     "json-stringify-pretty-compact": "^3.0.0",
     "minimist": "^1.2.8",
     "rw": "^1.3.3",

--- a/src/expression/definitions/interpolate.ts
+++ b/src/expression/definitions/interpolate.ts
@@ -1,9 +1,8 @@
 import UnitBezier from '@mapbox/unitbezier';
 
-import * as interpolate from '../../util/interpolate';
+import interpolate from '../../util/interpolate';
 import {toString, NumberType, ColorType} from '../types';
 import {findStopLessThanOrEqualTo} from '../stops';
-import {hcl, lab} from '../../util/color_spaces';
 
 import type {Stops} from '../stops';
 import type {Expression} from '../expression';
@@ -174,12 +173,13 @@ class Interpolate implements Expression {
         const outputLower = outputs[index].evaluate(ctx);
         const outputUpper = outputs[index + 1].evaluate(ctx);
 
-        if (this.operator === 'interpolate') {
-            return ((interpolate[this.type.kind.toLowerCase()] as any))(outputLower, outputUpper, t); // eslint-disable-line import/namespace
-        } else if (this.operator === 'interpolate-hcl') {
-            return hcl.reverse(hcl.interpolate(hcl.forward(outputLower), hcl.forward(outputUpper), t));
-        } else {
-            return lab.reverse(lab.interpolate(lab.forward(outputLower), lab.forward(outputUpper), t));
+        switch (this.operator) {
+            case 'interpolate':
+                return interpolate[this.type.kind.toLowerCase()](outputLower, outputUpper, t);
+            case 'interpolate-hcl':
+                return interpolate.color(outputLower, outputUpper, t, 'hcl');
+            case 'interpolate-lab':
+                return interpolate.color(outputLower, outputUpper, t, 'lab');
         }
     }
 

--- a/src/function/index.test.ts
+++ b/src/function/index.test.ts
@@ -175,52 +175,49 @@ describe('exponential function', () => {
             type: 'color'
         }).evaluate;
 
-        expect(f({zoom: 0}, undefined)).toEqual(new Color(1, 0, 0, 1));
-        expect(f({zoom: 5}, undefined)).toEqual(new Color(0.6, 0, 0.4, 1));
-        expect(f({zoom: 11}, undefined)).toEqual(new Color(0, 0, 1, 1));
-
+        expect(f({zoom: 0}, undefined)).toMatchColor('rgb(100% 0% 0% / 1)');
+        expect(f({zoom: 5}, undefined)).toMatchColor('rgb(60% 0% 40% / 1)');
+        expect(f({zoom: 11}, undefined)).toMatchColor('rgb(0% 0% 100% / 1)');
     });
 
-    test('lab colorspace', () => {
+    test('color hcl colorspace', () => {
+        const f = createFunction({
+            type: 'exponential',
+            colorSpace: 'hcl',
+            stops: [[0, 'rgb(36 98 36 / 0.6)'], [10, 'hsl(222,73%,32%)']],
+        }, {
+            type: 'color'
+        }).evaluate;
+
+        expect(f({zoom: 0}, undefined)).toMatchColor('rgb(14.12% 38.43% 14.12% / .6)', 4);
+        expect(f({zoom: 5}, undefined)).toMatchColor('rgb(0% 35.71% 46.73% / .8)', 4);
+        expect(f({zoom: 10}, undefined)).toMatchColor('rgb(8.64% 22.66% 55.36% / 1)', 4);
+    });
+
+    test('color lab colorspace', () => {
         const f = createFunction({
             type: 'exponential',
             colorSpace: 'lab',
-            stops: [[1, 'rgba(0,0,0,1)'], [10, 'rgba(0,255,255,1)']]
+            stops: [[0, '#0009'], [10, 'rgba(0,255,255,1)']],
         }, {
             type: 'color'
         }).evaluate;
 
-        expect(f({zoom: 0}, undefined)).toEqual(new Color(0, 0, 0, 1));
-        expect(f({zoom: 5}, undefined).r).toBeCloseTo(0);
-        expect(f({zoom: 5}, undefined).g).toBeCloseTo(0.444);
-        expect(f({zoom: 5}, undefined).b).toBeCloseTo(0.444);
-
+        expect(f({zoom: 0}, undefined)).toMatchColor('rgb(0% 0% 0% / .6)');
+        expect(f({zoom: 5}, undefined)).toMatchColor('rgb(14.29% 46.73% 46.63% / .8)', 4);
+        expect(f({zoom: 10}, undefined)).toMatchColor('rgb(0% 100% 100% / 1)');
     });
 
-    test('rgb colorspace', () => {
-        const f = createFunction({
-            type: 'exponential',
-            colorSpace: 'rgb',
-            stops: [[0, 'rgba(0,0,0,1)'], [10, 'rgba(255,255,255,1)']]
-        }, {
-            type: 'color'
-        }).evaluate;
-
-        expect(f({zoom: 5}, undefined)).toEqual(new Color(0.5, 0.5, 0.5, 1));
-
-    });
-
-    test('unknown color spaces', () => {
+    test('color invalid colorspace', () => {
         expect(() => {
             createFunction({
                 type: 'exponential',
-                colorSpace: 'unknown',
+                colorSpace: 'invalid',
                 stops: [[1, [0, 0, 0, 1]], [10, [0, 1, 1, 1]]]
             }, {
                 type: 'color'
             });
-        }).toThrow();
-
+        }).toThrow('Unknown color space: "invalid"');
     });
 
     test('interpolation mutation avoidance', () => {

--- a/src/util/color.test.ts
+++ b/src/util/color.test.ts
@@ -1,18 +1,72 @@
 import Color from './color';
 
-describe('Color', () => {
-    test('Color.parse', () => {
-        expect(Color.parse('red')).toEqual(new Color(1, 0, 0, 1));
-        expect(Color.parse('#ff00ff')).toEqual(new Color(1, 0, 1, 1));
-        expect(Color.parse('invalid')).toBeUndefined();
-        expect(Color.parse(null)).toBeUndefined();
-        expect(Color.parse(undefined)).toBeUndefined();
+describe('Color class', () => {
+
+    describe('parsing', () => {
+
+        test('should parse color keyword', () => {
+            expect(Color.parse('white')).toMatchColor('rgb(100% 100% 100% / 1)');
+            expect(Color.parse('black')).toMatchColor('rgb(0% 0% 0% / 1)');
+            expect(Color.parse('RED')).toMatchColor('rgb(100% 0% 0% / 1)');
+            expect(Color.parse('aquamarine')).toMatchColor('rgb(49.804% 100% 83.137% / 1)');
+            expect(Color.parse('steelblue')).toMatchColor('rgb(27.451% 50.98% 70.588% / 1)');
+        });
+
+        test('should parse hex color notation', () => {
+            expect(Color.parse('#fff')).toMatchColor('rgb(100% 100% 100% / 1)');
+            expect(Color.parse('#000')).toMatchColor('rgb(0% 0% 0% / 1)');
+            expect(Color.parse('#f00C')).toMatchColor('rgb(100% 0% 0% / .8)');
+            expect(Color.parse('#ff00ff')).toMatchColor('rgb(100% 0% 100% / 1)');
+            expect(Color.parse('#4682B466')).toMatchColor('rgb(27.451% 50.98% 70.588% / .4)');
+        });
+
+        test('should parse rgb function syntax', () => {
+            expect(Color.parse('rgb(0,0,128)')).toMatchColor('rgb(0% 0% 50.196% / 1)');
+            expect(Color.parse('rgb(0 0 128)')).toMatchColor('rgb(0% 0% 50.196% / 1)');
+            expect(Color.parse('rgb(0 0 128 / 0.2)')).toMatchColor('rgb(0% 0% 50.196% / .2)');
+            expect(Color.parse('rgb(0 0 128 / .2)')).toMatchColor('rgb(0% 0% 50.196% / .2)');
+            expect(Color.parse('rgb(0 0 128 / 20%)')).toMatchColor('rgb(0% 0% 50.196% / .2)');
+            expect(Color.parse('rgb(26,207,26,0.5)')).toMatchColor('rgb(10.196% 81.176% 10.196% / .5)');
+            expect(Color.parse('rgba(26,207,26,.73)')).toMatchColor('rgb(10.196% 81.176% 10.196% / .73)');
+            expect(Color.parse('rgba(0,0,128,.2)')).toMatchColor('rgb(0% 0% 50.196% / .2)');
+        });
+
+        test('should parse hsl function syntax', () => {
+            expect(Color.parse('hsl(300,100%,25.1%)')).toMatchColor('rgb(50.2% 0% 50.2% / 1)');
+            expect(Color.parse('hsl(300 100% 25.1%)')).toMatchColor('rgb(50.2% 0% 50.2% / 1)');
+            expect(Color.parse('hsl(300 100% 25.1% / 0.2)')).toMatchColor('rgb(50.2% 0% 50.2% / .2)');
+            expect(Color.parse('hsl(300 100% 25.1% / .2)')).toMatchColor('rgb(50.2% 0% 50.2% / .2)');
+            // expect(Color.parse('hsl(300 100% 25.1% / 20%)')).toMatchColor('rgb(50.2% 0% 50.2% / .2)');
+            expect(Color.parse('hsl(300,100%,25.1%,0.7)')).toMatchColor('rgb(50.2% 0% 50.2% / .7)');
+            expect(Color.parse('hsl(300deg 100% 25.1% / 0.7)')).toMatchColor('rgb(50.2% 0% 50.2% / .7)');
+            expect(Color.parse('hsla(300,100%,25.1%,0.9)')).toMatchColor('rgb(50.2% 0% 50.2% / .9)');
+            expect(Color.parse('hsla(300,100%,25.1%,.0)')).toMatchColor('rgb(50.2% 0% 50.2% / 0)');
+        });
+
+        test('should return undefined when provided with invalid CSS color string', () => {
+            expect(Color.parse(undefined)).toBeUndefined();
+            expect(Color.parse(null)).toBeUndefined();
+            expect(Color.parse('#invalid')).toBeUndefined();
+            expect(Color.parse('$123')).toBeUndefined();
+            expect(Color.parse('0F91')).toBeUndefined();
+            expect(Color.parse('rgb(#123)')).toBeUndefined();
+            expect(Color.parse('hsl(0,0,0)')).toBeUndefined();
+            expect(Color.parse('rgb(0deg,0,0)')).toBeUndefined();
+        });
+
+        test('should keep a reference to the original color when alpha=0', () => {
+            const color = Color.parse('rgba(0,0,128,0)');
+            expect(color).toMatchObject({r: 0, g: 0, b: 0, a: 0});
+            expect(Object.hasOwn(color, 'rgb')).toBe(true);
+            expect(color[ 'rgb' ]).closeToNumberArray([0, 0, 128 / 255, 0]);
+        });
+
+        test('should not keep a reference to the original color when alpha!=0', () => {
+            const color = Color.parse('rgba(0,0,128,0.001)');
+            expect(color).toMatchObject({r: 0, g: 0, b: expect.closeTo(128 / 255 * 0.001, 5), a: 0.001});
+            expect(Object.hasOwn(color, 'rgb')).toBe(false);
+        });
+
     });
 
-    test('Color#toString', () => {
-        const purple = Color.parse('purple');
-        expect(purple && purple.toString()).toBe('rgba(128,0,128,1)');
-        const translucentGreen = Color.parse('rgba(26, 207, 26, .73)');
-        expect(translucentGreen && translucentGreen.toString()).toBe('rgba(26,207,26,0.73)');
-    });
 });

--- a/src/util/color_spaces.test.ts
+++ b/src/util/color_spaces.test.ts
@@ -1,28 +1,71 @@
-import * as colorSpaces from './color_spaces';
-import Color from './color';
+import {hcl, hsl, lab} from './color_spaces';
 
 describe('color spaces', () => {
-    test('#hclToRgb zero', () => {
-        const hclColor = {h: 0, c: 0, l: 0, alpha: null};
-        const rgbColor = new Color(0, 0, 0, null);
-        expect(colorSpaces.hcl.reverse(hclColor)).toEqual(rgbColor);
+
+    describe('LAB color space', () => {
+
+        test('should convert colors from sRGB to LAB color space', () => {
+            expect(lab.fromRgb([0, 0, 0, 1])).closeToNumberArray([0, 0, 0, 1]);
+            expect(lab.fromRgb([1, 1, 1, 1])).closeToNumberArray([100, 0, 0, 1], 4);
+            expect(lab.fromRgb([0, 1, 0, 1])).closeToNumberArray([87.73, -86.18, 83.18, 1], 2);
+            expect(lab.fromRgb([0, 1, 1, 1])).closeToNumberArray([91.11, -48.09, -14.13, 1], 2);
+            expect(lab.fromRgb([0, 0, 1, 1])).closeToNumberArray([32.3, 79.19, -107.86, 1], 2);
+            expect(lab.fromRgb([1, 1, 0, 1])).closeToNumberArray([97.14, -21.55, 94.48, 1], 2);
+            expect(lab.fromRgb([1, 0, 0, 1])).closeToNumberArray([53.24, 80.09, 67.2, 1], 2);
+        });
+
+        test('should convert colors from LAB to sRGB color space', () => {
+            expect(lab.toRgb([0, 0, 0, 1])).closeToNumberArray([0, 0, 0, 1]);
+            expect(lab.toRgb([100, 0, 0, 1])).closeToNumberArray([1, 1, 1, 1]);
+            expect(lab.toRgb([50, 50, 0, 1])).closeToNumberArray([0.7605, 0.3096, 0.4734, 1], 4);
+            expect(lab.toRgb([70, -45, 0, 1])).closeToNumberArray([0.0469, 0.7537, 0.6656, 1], 4);
+            expect(lab.toRgb([70, 0, 70, 1])).closeToNumberArray([0.7955, 0.6590, 0.0818, 1], 4);
+            expect(lab.toRgb([55, 0, -60, 1])).closeToNumberArray([0, 0.5403, 0.9255, 1], 4);
+            expect(lab.toRgb([32.3, 79.19, -107.86, 1])).closeToNumberArray([0, 0, 1, 1], 3);
+        });
+
     });
 
-    test('#hclToRgb', () => {
-        const hclColor = {h: 20, c: 20, l: 20, alpha: null};
-        const rgbColor = new Color(76.04087881379073, 36.681898967046166, 39.08743507357837, null);
-        expect(colorSpaces.hcl.reverse(hclColor)).toEqual(rgbColor);
+    describe('HCL color space', () => {
+
+        test('should convert colors from sRGB to HCL color space', () => {
+            expect(hcl.fromRgb([0, 0, 0, 1])).closeToNumberArray([NaN, 0, 0, 1]);
+            expect(hcl.fromRgb([1, 1, 1, 1])).closeToNumberArray([NaN, 0, 100, 1], 4);
+            expect(hcl.fromRgb([0, 1, 0, 1])).closeToNumberArray([136.02, 119.78, 87.73, 1], 2);
+            expect(hcl.fromRgb([0, 1, 1, 1])).closeToNumberArray([196.38, 50.12, 91.11, 1], 2);
+            expect(hcl.fromRgb([0, 0, 1, 1])).closeToNumberArray([306.28, 133.81, 32.30, 1], 2);
+            expect(hcl.fromRgb([1, 1, 0, 1])).closeToNumberArray([102.85, 96.91, 97.14, 1], 2);
+            expect(hcl.fromRgb([1, 0, 0, 1])).closeToNumberArray([40.00, 104.55, 53.24, 1], 2);
+        });
+
+        test('should convert colors from HCL to sRGB color space', () => {
+            expect(hcl.toRgb([0, 0, 0, 1])).closeToNumberArray([0, 0, 0, 1]);
+            expect(hcl.toRgb([0, 0, 100, 1])).closeToNumberArray([1, 1, 1, 1]);
+            expect(hcl.toRgb([0, 50, 50, 1])).closeToNumberArray([0.7605, 0.3096, 0.4734, 1], 4);
+            expect(hcl.toRgb([180, 45, 70, 1])).closeToNumberArray([0.0469, 0.7537, 0.6656, 1], 4);
+            expect(hcl.toRgb([90, 70, 70, 1])).closeToNumberArray([0.7955, 0.6590, 0.0818, 1], 4);
+            expect(hcl.toRgb([270, 60, 55, 1])).closeToNumberArray([0, 0.5403, 0.9255, 1], 4);
+            expect(hcl.toRgb([306.28, 133.81, 32.30, 1])).closeToNumberArray([0, 0, 1, 1], 3);
+        });
+
     });
 
-    test('#rgbToHcl zero', () => {
-        const hclColor = {h: 0, c: 0, l: 0, alpha: null};
-        const rgbColor = new Color(0, 0, 0, null);
-        expect(colorSpaces.hcl.forward(rgbColor)).toEqual(hclColor);
+    describe('HSL color space', () => {
+
+        test('should convert colors from HSL to sRGB color space', () => {
+            expect(hsl.toRgb([0, 0, 0, 1])).closeToNumberArray([0, 0, 0, 1]);
+            expect(hsl.toRgb([0, 100, 0, 1])).closeToNumberArray([0, 0, 0, 1]);
+            expect(hsl.toRgb([0, 0, 100, 1])).closeToNumberArray([1, 1, 1, 1]);
+            expect(hsl.toRgb([360, 0, 0, 1])).closeToNumberArray([0, 0, 0, 1]);
+            expect(hsl.toRgb([120, 100, 25, 1])).closeToNumberArray([0, 128 / 255, 0, 1], 2);
+            expect(hsl.toRgb([120, 30, 50, 0])).closeToNumberArray([89 / 255, 166 / 255, 89 / 255, 0], 2);
+            expect(hsl.toRgb([240, 25, 50, 0.1])).closeToNumberArray([96 / 255, 96 / 255, 159 / 255, 0.1], 2);
+            expect(hsl.toRgb([240, 50, 50, 0.8])).closeToNumberArray([64 / 255, 64 / 255, 191 / 255, 0.8], 2);
+            expect(hsl.toRgb([270, 75, 75, 1])).closeToNumberArray([191 / 255, 143 / 255, 239 / 255, 1], 2);
+            expect(hsl.toRgb([300, 100, 50, 0.5])).closeToNumberArray([1, 0, 1, 0.5]);
+            expect(hsl.toRgb([330, 0, 25, 0.3])).closeToNumberArray([64 / 255, 64 / 255, 64 / 255, 0.3], 2);
+        });
+
     });
 
-    test('#rgbToHcl', () => {
-        const hclColor = {h: 158.19859051364818, c: 0.0000029334887311101764, l: 6.318928745123017, alpha: null};
-        const rgbColor = new Color(20, 20, 20, null);
-        expect(colorSpaces.hcl.forward(rgbColor)).toEqual(hclColor);
-    });
 });

--- a/src/util/color_spaces.ts
+++ b/src/util/color_spaces.ts
@@ -1,20 +1,34 @@
-import Color from './color';
+/**
+ * @param r Red component 0..1
+ * @param g Green component 0..1
+ * @param b Blue component 0..1
+ * @param alpha Alpha component 0..1
+ */
+export type RGBColor = [r: number, g: number, b: number, alpha: number];
 
-import {number as interpolateNumber} from './interpolate';
+/**
+ * @param h Hue as degrees 0..360
+ * @param s Saturation as percentage 0..100
+ * @param l Lightness as percentage 0..100
+ * @param alpha Alpha component 0..1
+ */
+export type HSLColor = [h: number, s: number, l: number, alpha: number];
 
-type LABColor = {
-    l: number;
-    a: number;
-    b: number;
-    alpha: number;
-};
+/**
+ * @param h Hue as degrees 0..360
+ * @param c Chroma 0..~230
+ * @param l Lightness as percentage 0..100
+ * @param alpha Alpha component 0..1
+ */
+export type HCLColor = [h: number, c: number, l: number, alpha: number];
 
-type HCLColor = {
-    h: number;
-    c: number;
-    l: number;
-    alpha: number;
-};
+/**
+ * @param l Lightness as percentage 0..100
+ * @param a A axis value -125..125
+ * @param b B axis value -125..125
+ * @param alpha Alpha component 0..1
+ */
+export type LABColor = [l: number, a: number, b: number, alpha: number];
 
 // Constants
 const Xn = 0.950470, // D65 standard referent
@@ -27,111 +41,101 @@ const Xn = 0.950470, // D65 standard referent
     deg2rad = Math.PI / 180,
     rad2deg = 180 / Math.PI;
 
-// Utilities
-function xyz2lab(t: number) {
-    return t > t3 ? Math.pow(t, 1 / 3) : t / t2 + t0;
+function constrainAngle(angle: number): number {
+    angle = angle % 360;
+    if (angle < 0) {
+        angle += 360;
+    }
+    return angle;
 }
 
-function lab2xyz(t: number) {
-    return t > t1 ? t * t * t : t2 * (t - t0);
+// sRGB -> LAB
+function rgbToLab([r, g, b, alpha]: RGBColor): LABColor {
+    r = rgb2xyz(r);
+    g = rgb2xyz(g);
+    b = rgb2xyz(b);
+    const x = xyz2lab((0.4124564 * r + 0.3575761 * g + 0.1804375 * b) / Xn);
+    const y = xyz2lab((0.2126729 * r + 0.7151522 * g + 0.0721750 * b) / Yn);
+    const z = xyz2lab((0.0193339 * r + 0.1191920 * g + 0.9503041 * b) / Zn);
+
+    const l = 116 * y - 16;
+    return [(l < 0) ? 0 : l, 500 * (x - y), 200 * (y - z), alpha];
 }
 
-function xyz2rgb(x: number) {
-    return 255 * (x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055);
+function rgb2xyz(x: number): number {
+    return (x <= 0.04045) ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
 }
 
-function rgb2xyz(x: number) {
-    x /= 255;
-    return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+function xyz2lab(t: number): number {
+    return (t > t3) ? Math.pow(t, 1 / 3) : t / t2 + t0;
 }
 
-// LAB
-function rgbToLab(rgbColor: Color): LABColor {
-    const b = rgb2xyz(rgbColor.r),
-        a = rgb2xyz(rgbColor.g),
-        l = rgb2xyz(rgbColor.b),
-        x = xyz2lab((0.4124564 * b + 0.3575761 * a + 0.1804375 * l) / Xn),
-        y = xyz2lab((0.2126729 * b + 0.7151522 * a + 0.0721750 * l) / Yn),
-        z = xyz2lab((0.0193339 * b + 0.1191920 * a + 0.9503041 * l) / Zn);
+// LAB -> sRGB
+function labToRgb([l, a, b, alpha]: LABColor): RGBColor {
+    let y = (l + 16) / 116,
+        x = isNaN(a) ? y : y + a / 500,
+        z = isNaN(b) ? y : y - b / 200;
 
-    return {
-        l: 116 * y - 16,
-        a: 500 * (x - y),
-        b: 200 * (y - z),
-        alpha: rgbColor.a
-    };
-}
-
-function labToRgb(labColor: LABColor): Color {
-    let y = (labColor.l + 16) / 116,
-        x = isNaN(labColor.a) ? y : y + labColor.a / 500,
-        z = isNaN(labColor.b) ? y : y - labColor.b / 200;
     y = Yn * lab2xyz(y);
     x = Xn * lab2xyz(x);
     z = Zn * lab2xyz(z);
-    return new Color(
+
+    return [
         xyz2rgb(3.2404542 * x - 1.5371385 * y - 0.4985314 * z), // D65 -> sRGB
         xyz2rgb(-0.9692660 * x + 1.8760108 * y + 0.0415560 * z),
         xyz2rgb(0.0556434 * x - 0.2040259 * y + 1.0572252 * z),
-        labColor.alpha
-    );
+        alpha,
+    ];
 }
 
-function interpolateLab(from: LABColor, to: LABColor, t: number) {
-    return {
-        l: interpolateNumber(from.l, to.l, t),
-        a: interpolateNumber(from.a, to.a, t),
-        b: interpolateNumber(from.b, to.b, t),
-        alpha: interpolateNumber(from.alpha, to.alpha, t)
-    };
+function xyz2rgb(x: number): number {
+    x = (x <= 0.00304) ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055;
+    return (x < 0) ? 0 : (x > 1) ? 1 : x; // clip to 0..1 range
 }
 
-// HCL
-function rgbToHcl(rgbColor: Color): HCLColor {
-    const {l, a, b} = rgbToLab(rgbColor);
-    const h = Math.atan2(b, a) * rad2deg;
-    return {
-        h: h < 0 ? h + 360 : h,
-        c: Math.sqrt(a * a + b * b),
-        l,
-        alpha: rgbColor.a
-    };
+function lab2xyz(t: number): number {
+    return (t > t1) ? t * t * t : t2 * (t - t0);
 }
 
-function hclToRgb(hclColor: HCLColor): Color {
-    const h = hclColor.h * deg2rad,
-        c = hclColor.c,
-        l = hclColor.l;
-    return labToRgb({
-        l,
-        a: Math.cos(h) * c,
-        b: Math.sin(h) * c,
-        alpha: hclColor.alpha
-    });
+// sRGB -> HCL
+function rgbToHcl(rgbColor: RGBColor): HCLColor {
+    const [l, a, b, alpha] = rgbToLab(rgbColor);
+    const c = Math.sqrt(a * a + b * b);
+    const h = Math.round(c * 10000) ? constrainAngle(Math.atan2(b, a) * rad2deg) : NaN;
+    return [h, c, l, alpha];
 }
 
-function interpolateHue(a: number, b: number, t: number) {
-    const d = b - a;
-    return a + t * (d > 180 || d < -180 ? d - 360 * Math.round(d / 360) : d);
+// HCL -> sRGB
+function hclToRgb([h, c, l, alpha]: HCLColor): RGBColor {
+    h = isNaN(h) ? 0 : h * deg2rad;
+    return labToRgb([l, Math.cos(h) * c, Math.sin(h) * c, alpha]);
 }
 
-function interpolateHcl(from: HCLColor, to: HCLColor, t: number) {
-    return {
-        h: interpolateHue(from.h, to.h, t),
-        c: interpolateNumber(from.c, to.c, t),
-        l: interpolateNumber(from.l, to.l, t),
-        alpha: interpolateNumber(from.alpha, to.alpha, t)
-    };
+// HSL -> sRGB https://drafts.csswg.org/css-color-4/#hsl-to-rgb
+function hslToRgb([h, s, l, alpha]: HSLColor): RGBColor {
+    h = constrainAngle(h);
+    s /= 100;
+    l /= 100;
+
+    function f(n) {
+        const k = (n + h / 30) % 12;
+        const a = s * Math.min(l, 1 - l);
+        return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+    }
+
+    return [f(0), f(8), f(4), alpha];
 }
 
 export const lab = {
-    forward: rgbToLab,
-    reverse: labToRgb,
-    interpolate: interpolateLab
+    fromRgb: rgbToLab,
+    toRgb: labToRgb,
 };
 
 export const hcl = {
-    forward: rgbToHcl,
-    reverse: hclToRgb,
-    interpolate: interpolateHcl
+    fromRgb: rgbToHcl,
+    toRgb: hclToRgb,
+};
+
+export const hsl = {
+    toRgb: hslToRgb,
 };

--- a/src/util/interpolate.test.ts
+++ b/src/util/interpolate.test.ts
@@ -1,21 +1,111 @@
-import * as interpolate from './interpolate';
+import interpolate, {isSupportedInterpolationColorSpace} from './interpolate';
 import Color from './color';
 import Padding from './padding';
 
 describe('interpolate', () => {
-    test('interpolate.number', () => {
+
+    test('interpolate number', () => {
+        expect(interpolate.number(-5, 5, 0.00)).toBe(-5.0);
+        expect(interpolate.number(-5, 5, 0.25)).toBe(-2.5);
+        expect(interpolate.number(-5, 5, 0.50)).toBe(0);
+        expect(interpolate.number(-5, 5, 0.75)).toBe(2.5);
+        expect(interpolate.number(-5, 5, 1.00)).toBe(5.0);
+
         expect(interpolate.number(0, 1, 0.5)).toBe(0.5);
+        expect(interpolate.number(-10, -5, 0.5)).toBe(-7.5);
+        expect(interpolate.number(5, 10, 0.5)).toBe(7.5);
     });
 
-    test('interpolate.color', () => {
-        expect(interpolate.color(new Color(0, 0, 0, 0), new Color(1, 2, 3, 4), 0.5)).toEqual(new Color(0.5, 1, 3 / 2, 2));
+    describe('interpolation color space', () => {
+
+        test('should recognize supported interpolation color spaces', () => {
+            expect(isSupportedInterpolationColorSpace('rgb')).toBe(true);
+            expect(isSupportedInterpolationColorSpace('hcl')).toBe(true);
+            expect(isSupportedInterpolationColorSpace('lab')).toBe(true);
+        });
+
+        test('should ignore invalid interpolation color spaces', () => {
+            expect(isSupportedInterpolationColorSpace('sRGB')).toBe(false);
+            expect(isSupportedInterpolationColorSpace('HCL')).toBe(false);
+            expect(isSupportedInterpolationColorSpace('LCH')).toBe(false);
+            expect(isSupportedInterpolationColorSpace('LAB')).toBe(false);
+            expect(isSupportedInterpolationColorSpace('interpolate')).toBe(false);
+            expect(isSupportedInterpolationColorSpace('interpolate-hcl')).toBe(false);
+            expect(isSupportedInterpolationColorSpace('interpolate-lab')).toBe(false);
+        });
+
     });
 
-    test('interpolate.array', () => {
+    describe('interpolate color', () => {
+
+        test('should interpolate colors in "rgb" color space', () => {
+            const color = Color.parse('rgba(0,0,255,1)');
+            const targetColor = Color.parse('rgba(0,255,0,.6)');
+
+            const i11nFn = (t: number) => interpolate.color(color, targetColor, t, 'rgb');
+            expect(i11nFn(0.00)).toMatchColor('rgb(0% 0% 100% / 1)');
+            expect(i11nFn(0.25)).toMatchColor('rgb(0% 25% 75% / 0.9)');
+            expect(i11nFn(0.50)).toMatchColor('rgb(0% 50% 50% / 0.8)');
+            expect(i11nFn(0.75)).toMatchColor('rgb(0% 75% 25% / 0.7)');
+            expect(i11nFn(1.00)).toMatchColor('rgb(0% 100% 0% / 0.6)');
+        });
+
+        test('should interpolate colors in "hcl" color space', () => {
+            const color = Color.parse('rgba(0,0,255,1)');
+            const targetColor = Color.parse('rgba(0,255,0,.6)');
+
+            const i11nFn = (t: number) => interpolate.color(color, targetColor, t, 'hcl');
+            expect(i11nFn(0.00)).toMatchColor('rgb(0% 0% 100% / 1)');
+            expect(i11nFn(0.25)).toMatchColor('rgb(0% 53.05% 100% / 0.9)', 4);
+            expect(i11nFn(0.50)).toMatchColor('rgb(0% 72.97% 100% / 0.8)', 4);
+            expect(i11nFn(0.75)).toMatchColor('rgb(0% 88.42% 67.80% / 0.7)', 4);
+            expect(i11nFn(1.00)).toMatchColor('rgb(0% 100% 0% / 0.6)');
+        });
+
+        test('should interpolate colors in "lab" color space', () => {
+            const color = Color.parse('rgba(0,0,255,1)');
+            const targetColor = Color.parse('rgba(0,255,0,.6)');
+
+            const i11nFn = (t: number) => interpolate.color(color, targetColor, t, 'lab');
+            expect(i11nFn(0.00)).toMatchColor('rgb(0% 0% 100% / 1)');
+            expect(i11nFn(0.25)).toMatchColor('rgb(42.40% 35.65% 82.90% / 0.9)', 4);
+            expect(i11nFn(0.50)).toMatchColor('rgb(49.19% 57.81% 65.10% / 0.8)', 4);
+            expect(i11nFn(0.75)).toMatchColor('rgb(43.61% 78.93% 44.66% / 0.7)', 4);
+            expect(i11nFn(1.00)).toMatchColor('rgb(0% 100% 0% / 0.6)');
+        });
+
+        test('should correctly interpolate colors with alpha=0', () => {
+            const color = Color.parse('rgba(0,0,255,0)');
+            const targetColor = Color.parse('rgba(0,255,0,1)');
+
+            const i11nFn = (t: number) => interpolate.color(color, targetColor, t, 'rgb');
+            expect(i11nFn(0.00)).toMatchColor('rgb(0% 0% 100% / 0)');
+            expect(i11nFn(0.25)).toMatchColor('rgb(0% 25% 75% / 0.25)');
+            expect(i11nFn(0.50)).toMatchColor('rgb(0% 50% 50% / 0.5)');
+            expect(i11nFn(0.75)).toMatchColor('rgb(0% 75% 25% / 0.75)');
+            expect(i11nFn(1.00)).toMatchColor('rgb(0% 100% 0% / 1)');
+        });
+
+        test('should limit interpolation results to sRGB gamut', () => {
+            const color = Color.parse('royalblue');
+            const targetColor = Color.parse('cyan');
+
+            const i11nFn = (t: number) => interpolate.color(color, targetColor, t, 'hcl');
+            const colorInBetween = i11nFn(0.5);
+            for (const key of ['r', 'g', 'b', 'a']) {
+                expect(colorInBetween[ key ]).toBeGreaterThanOrEqual(0);
+                expect(colorInBetween[ key ]).toBeLessThanOrEqual(1);
+            }
+        });
+
+    });
+
+    test('interpolate array', () => {
         expect(interpolate.array([0, 0, 0, 0], [1, 2, 3, 4], 0.5)).toEqual([0.5, 1, 3 / 2, 2]);
     });
 
-    test('interpolate.padding', () => {
+    test('interpolate padding', () => {
         expect(interpolate.padding(new Padding([0, 0, 0, 0]), new Padding([1, 2, 3, 4]), 0.5)).toEqual(new Padding([0.5, 1, 3 / 2, 2]));
     });
+
 });

--- a/src/util/interpolate.ts
+++ b/src/util/interpolate.ts
@@ -1,6 +1,25 @@
+import {hcl, lab, RGBColor} from './color_spaces';
 import Color from './color';
 import Padding from './padding';
 
+export type InterpolationColorSpace = keyof typeof colorInterpolation;
+
+/**
+ * Checks whether the specified color space is one of the supported interpolation color spaces.
+ *
+ * @param colorSpace Color space key to verify.
+ * @returns `true` if the specified color space is one of the supported
+ * interpolation color spaces, `false` otherwise
+ */
+export function isSupportedInterpolationColorSpace(colorSpace: string): colorSpace is InterpolationColorSpace {
+    return colorSpace in colorInterpolation;
+}
+
+/**
+ * @param interpolationType Interpolation type
+ * @returns interpolation fn
+ * @deprecated use `interpolate[type]` instead
+ */
 export const interpolateFactory = (interpolationType: 'number'|'color'|'array'|'padding') => {
     switch (interpolationType) {
         case 'number': return number;
@@ -10,41 +29,92 @@ export const interpolateFactory = (interpolationType: 'number'|'color'|'array'|'
     }
 };
 
-export function number(a: number, b: number, t: number) {
-    return (a * (1 - t)) + (b * t);
+function number(from: number, to: number, t: number): number {
+    return from + t * (to - from);
 }
 
-export function color(from: Color, to: Color, t: number) {
-    return new Color(
-        number(from.r, to.r, t),
-        number(from.g, to.g, t),
-        number(from.b, to.b, t),
-        number(from.a, to.a, t)
-    );
+const colorInterpolation = {
+    rgb: (from: Color, to: Color, t: number): RGBColor => {
+        const [rF, gF, bF, alphaF] = from.rgb;
+        const [rT, gT, bT, alphaT] = to.rgb;
+        return [
+            number(rF, rT, t),
+            number(gF, gT, t),
+            number(bF, bT, t),
+            number(alphaF, alphaT, t),
+        ];
+    },
+    hcl: (from: Color, to: Color, t: number): RGBColor => {
+        const [hue0, chroma0, light0, alphaF] = from.hcl;
+        const [hue1, chroma1, light1, alphaT] = to.hcl;
+
+        // https://github.com/gka/chroma.js/blob/cd1b3c0926c7a85cbdc3b1453b3a94006de91a92/src/interpolator/_hsx.js
+        let hue, chroma;
+
+        if (!isNaN(hue0) && !isNaN(hue1)) {
+            let dh = hue1 - hue0;
+            if (hue1 > hue0 && dh > 180) {
+                dh -= 360;
+            } else if (hue1 < hue0 && hue0 - hue1 > 180) {
+                dh += 360;
+            }
+            hue = hue0 + t * dh;
+        } else if (!isNaN(hue0)) {
+            hue = hue0;
+            if (light1 === 1 || light1 === 0) chroma = chroma0;
+        } else if (!isNaN(hue1)) {
+            hue = hue1;
+            if (light0 === 1 || light0 === 0) chroma = chroma1;
+        } else {
+            hue = NaN;
+        }
+
+        return hcl.toRgb([
+            hue,
+            chroma ?? number(chroma0, chroma1, t),
+            number(light0, light1, t),
+            number(alphaF, alphaT, t),
+        ]);
+    },
+    lab: (from: Color, to: Color, t: number): RGBColor => {
+        const [lF, aF, bF, alphaF] = from.lab;
+        const [lT, aT, bT, alphaT] = to.lab;
+        return lab.toRgb([
+            number(lF, lT, t),
+            number(aF, aT, t),
+            number(bF, bT, t),
+            number(alphaF, alphaT, t),
+        ]);
+    },
+};
+
+function color(from: Color, to: Color, t: number, spaceKey: InterpolationColorSpace = 'rgb'): Color {
+    const [r, g, b, alpha] = colorInterpolation[ spaceKey ](from, to, t);
+    return new Color(r * alpha, g * alpha, b * alpha, alpha);
 }
 
-export function array(from: Array<number>, to: Array<number>, t: number): Array<number> {
+function array(from: number[], to: number[], t: number): number[] {
     return from.map((d, i) => {
         return number(d, to[i], t);
     });
 }
 
-export function padding(from: Padding, to: Padding, t: number): Padding {
+function padding(from: Padding, to: Padding, t: number): Padding {
     const fromVal = from.values;
     const toVal = to.values;
     return new Padding([
         number(fromVal[0], toVal[0], t),
         number(fromVal[1], toVal[1], t),
         number(fromVal[2], toVal[2], t),
-        number(fromVal[3], toVal[3], t)
+        number(fromVal[3], toVal[3], t),
     ]);
 }
 
-const interpolates = {
+const interpolate = {
     number,
     color,
     array,
-    padding
+    padding,
 };
 
-export default interpolates;
+export default interpolate;

--- a/src/validate/validate_color.test.ts
+++ b/src/validate/validate_color.test.ts
@@ -1,0 +1,65 @@
+import validateColor from './validate_color';
+
+describe('validateColor function', () => {
+
+    const key = 'sample_color_key';
+
+    test('should return no errors when color is valid color string', () => {
+        const validColorStrings = [
+            'navajowhite',
+            '#123',
+            '#0F91',
+            '#00fF00',
+            '#0000ffcc',
+            'rgb(0,0,0)',
+            'rgba(28,148,103,0.5)',
+            'rgb(28 148 103 / 50%)',
+            'hsl(0 0% 0%)',
+            'hsla(158,68.2%,34.5%,0.5)',
+        ];
+
+        for (const value of validColorStrings) {
+            expect(validateColor({key, value})).toEqual([]);
+        }
+    });
+
+    test('should return error when color is not a string', () => {
+        expect(validateColor({key, value: 0})).toMatchObject([
+            {message: `${key}: color expected, number found`},
+        ]);
+        expect(validateColor({key, value: [0, 0, 0]})).toMatchObject([
+            {message: `${key}: color expected, array found`},
+        ]);
+        expect(validateColor({key, value: {}})).toMatchObject([
+            {message: `${key}: color expected, object found`},
+        ]);
+        expect(validateColor({key, value: false})).toMatchObject([
+            {message: `${key}: color expected, boolean found`},
+        ]);
+        expect(validateColor({key, value: null})).toMatchObject([
+            {message: `${key}: color expected, null found`},
+        ]);
+        expect(validateColor({key, value: undefined})).toMatchObject([
+            {message: `${key}: color expected, undefined found`},
+        ]);
+    });
+
+    test('should return error when color is invalid color string', () => {
+        const invalidColorStrings = [
+            'navajo_white',
+            '#123g',
+            '0F91',
+            'rgb(28 148 / 0.8)',
+            'rgb(28 148 103 0.5)',
+            'rgb(28 148 103 / 0.5 2)',
+            'hsl(0,0,0)',
+        ];
+
+        for (const value of invalidColorStrings) {
+            expect(validateColor({key, value})).toEqual([
+                {message: `${key}: color expected, "${value}" found`},
+            ]);
+        }
+    });
+
+});

--- a/src/validate/validate_color.ts
+++ b/src/validate/validate_color.ts
@@ -1,7 +1,6 @@
-
 import ValidationError from '../error/validation_error';
 import getType from '../util/get_type';
-import {parseCSSColor} from 'csscolorparser';
+import Color from '../util/color';
 
 export default function validateColor(options) {
     const key = options.key;
@@ -12,7 +11,7 @@ export default function validateColor(options) {
         return [new ValidationError(key, value, `color expected, ${type} found`)];
     }
 
-    if (parseCSSColor(value) === null) {
+    if (!Color.parse(value)) {
         return [new ValidationError(key, value, `color expected, "${value}" found`)];
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
     "experimentalSpecifierResolution": "node",
     "esm": true
   },
-  "include": ["rollup.config.*", "src/**/*", "build/**/*"],
+  "include": ["rollup.config.*", "src/**/*", "build/**/*", "jest.*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
- CSS Color 4 support
- Color interpolation changes, [see live demo](https://kajkal.github.io/maplibre-gl-style-spec-color-demo/)
    - fix interpolation in hcl and lab color spaces
    - include colors with alpha=0 in color interpolation calculations

See more in discussion #70 

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.